### PR TITLE
#94.1 - finish Q&A widget testing

### DIFF
--- a/__tests__/questions/QandAModal.test.jsx
+++ b/__tests__/questions/QandAModal.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import QandAModal from '../../client/src/components/Questions/QandAModal.jsx';
+import fetcherMock from '../../client/src/fetchers';
+
+jest.mock('../../client/src/fetchers');
+beforeEach(jest.clearAllMocks);
+
+test('renders Q modal properly', () => {
+  render(<div id="modal" />);
+  render(<QandAModal type="question" show />);
+  expect(screen.getByText(/ask your question/i)).toBeInTheDocument();
+});
+
+test('renders A modal properly', () => {
+  render(<div id="modal" />);
+  render(<QandAModal type="answer" show />);
+  expect(screen.getByText(/submit your answer/i)).toBeInTheDocument();
+});

--- a/__tests__/questions/QandAModal.test.jsx
+++ b/__tests__/questions/QandAModal.test.jsx
@@ -8,14 +8,70 @@ import fetcherMock from '../../client/src/fetchers';
 jest.mock('../../client/src/fetchers');
 beforeEach(jest.clearAllMocks);
 
-test('renders Q modal properly', () => {
+test('renders Q modal', () => {
   render(<div id="modal" />);
   render(<QandAModal type="question" show />);
   expect(screen.getByText(/ask your question/i)).toBeInTheDocument();
 });
 
-test('renders A modal properly', () => {
+test('text renders when user types', async () => {
+  render(<div id="modal" />);
+  render(<QandAModal type="question" show />);
+
+  await userEvent.type(screen.getByRole('textbox', { name: /question/i }), 'Why, Jack?');
+  await userEvent.type(screen.getByRole('textbox', { name: /nickname/i }), 'rosemary22');
+  await userEvent.type(screen.getByRole('textbox', { name: /email/i }), 'rose@mary.com');
+
+  expect(screen.getByRole('textbox', { name: /question/i })).toHaveValue('Why, Jack?');
+  expect(screen.getByRole('textbox', { name: /nickname/i })).toHaveValue('rosemary22');
+  expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('rose@mary.com');
+});
+
+test('posts question on submit', async () => {
+  fetcherMock.postQuestion.mockResolvedValueOnce();
+  render(<div id="modal" />);
+  render(<QandAModal type="question" setShowModal={jest.fn()} show />);
+
+  await userEvent.type(screen.getByRole('textbox', { name: /question/i }), 'Why, Jack?');
+  await userEvent.type(screen.getByRole('textbox', { name: /nickname/i }), 'rosemary22');
+  await userEvent.type(screen.getByRole('textbox', { name: /email/i }), 'rose@mary.com');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  expect(fetcherMock.postQuestion).toHaveBeenCalledTimes(1);
+});
+
+// test('doesn\'t post question on submit when required fields aren\'t met');
+
+test('renders A modal', () => {
   render(<div id="modal" />);
   render(<QandAModal type="answer" show />);
   expect(screen.getByText(/submit your answer/i)).toBeInTheDocument();
 });
+
+test('text renders when user types', async () => {
+  render(<div id="modal" />);
+  render(<QandAModal type="answer" show />);
+
+  await userEvent.type(screen.getByRole('textbox', { name: /answer/i }), 'IDK');
+  await userEvent.type(screen.getByRole('textbox', { name: /nickname/i }), 'jackson11!');
+  await userEvent.type(screen.getByRole('textbox', { name: /email/i }), 'json@eleven.com');
+
+  expect(screen.getByRole('textbox', { name: /answer/i })).toHaveValue('IDK');
+  expect(screen.getByRole('textbox', { name: /nickname/i })).toHaveValue('jackson11!');
+  expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('json@eleven.com');
+});
+
+test('posts answer on submit', async () => {
+  fetcherMock.postAnswer.mockResolvedValueOnce();
+  render(<div id="modal" />);
+  render(<QandAModal type="answer" setShowModal={jest.fn()} show />);
+
+  await userEvent.type(screen.getByRole('textbox', { name: /answer/i }), 'IDK');
+  await userEvent.type(screen.getByRole('textbox', { name: /nickname/i }), 'jackson11!');
+  await userEvent.type(screen.getByRole('textbox', { name: /email/i }), 'json@eleven.com');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  expect(fetcherMock.postAnswer).toHaveBeenCalledTimes(1);
+});
+
+// test('doesn\'t post answer on submit when required fields aren\'t met');

--- a/__tests__/questions/Question.test.jsx
+++ b/__tests__/questions/Question.test.jsx
@@ -76,12 +76,16 @@ test('clicking add answer link will render an answer modal', async () => {
   expect(screen.getByText(/submit your answer/i)).toBeInTheDocument();
 });
 
-test('clicking outside the answer modal closes it', () => {
+// there isn't a good way to test this, since we remove styling and the
+// modal-bg thus has no dimensions and doesn't cover everything
+// test('clicking outside the answer modal closes it');
+
+test('clicking cancel closes the answer modal', async () => {
   render(<div id="modal" />);
   render(<Question question={proxyQuestion} filterText="" />);
 
-  userEvent.click(screen.getByText(/add answer/i));
-  userEvent.click(screen.getByText(/q: /i));
+  await userEvent.click(screen.getByText(/add answer/i));
+  await userEvent.click(screen.getByText(/cancel/i));
 
   expect(screen.queryByText(/submit your answer/i)).not.toBeInTheDocument();
 });

--- a/__tests__/questions/Question.test.jsx
+++ b/__tests__/questions/Question.test.jsx
@@ -67,11 +67,21 @@ test('clicking LOAD MORE ANSWERS renders 1 more answer if less than 4 answers ex
   expect(answers.length).toBe(3);
 });
 
-test('clicking Add Answer will render an answer modal', async () => {
+test('clicking add answer link will render an answer modal', async () => {
   render(<div id="modal" />);
   render(<Question question={proxyQuestion} filterText="" />);
 
   await userEvent.click(screen.getByText(/add answer/i));
 
   expect(screen.getByText(/submit your answer/i)).toBeInTheDocument();
+});
+
+test('clicking outside the answer modal closes it', () => {
+  render(<div id="modal" />);
+  render(<Question question={proxyQuestion} filterText="" />);
+
+  userEvent.click(screen.getByText(/add answer/i));
+  userEvent.click(screen.getByText(/q: /i));
+
+  expect(screen.queryByText(/submit your answer/i)).not.toBeInTheDocument();
 });

--- a/__tests__/questions/QuestionsList.test.jsx
+++ b/__tests__/questions/QuestionsList.test.jsx
@@ -55,11 +55,20 @@ test('should only render questions with answers', async () => {
   expect(questions.length).toEqual(answers.length);
 });
 
-test('renders modal on ADD button click', async () => {
+test('clicking add a question button renders a question modal', async () => {
   render(<div id="modal" />);
   render(<QuestionsList questions={proxyQList} filterText="" />);
-  const button = screen.getByRole('button', { name: /add a question \+/i });
-  await userEvent.click(button);
+  await userEvent.click(screen.getByText(/add a question \+/i));
 
-  expect(await screen.findByText('Ask your Question')).toBeInTheDocument();
+  expect(screen.getByText(/ask your question/i)).toBeInTheDocument();
+});
+
+test('clicking outside the question modal closes it', () => {
+  render(<div id="modal" />);
+  render(<QuestionsList questions={proxyQList.slice(0, 1)} filterText="" />);
+
+  userEvent.click(screen.getByText(/add a question \+/i));
+  userEvent.click(screen.getByText(/q: /i));
+
+  expect(screen.queryByText(/ask your question/i)).not.toBeInTheDocument();
 });

--- a/__tests__/questions/QuestionsList.test.jsx
+++ b/__tests__/questions/QuestionsList.test.jsx
@@ -63,12 +63,16 @@ test('clicking add a question button renders a question modal', async () => {
   expect(screen.getByText(/ask your question/i)).toBeInTheDocument();
 });
 
-test('clicking outside the question modal closes it', () => {
-  render(<div id="modal" />);
-  render(<QuestionsList questions={proxyQList.slice(0, 1)} filterText="" />);
+// there isn't a good way to test this, since we remove styling and the
+// modal-bg thus has no dimensions and doesn't cover everything
+// test('clicking outside the question modal closes it');
 
-  userEvent.click(screen.getByText(/add a question \+/i));
-  userEvent.click(screen.getByText(/q: /i));
+test('clicking cancel closes the question modal', async () => {
+  render(<div id="modal" />);
+  render(<QuestionsList questions={proxyQList} filterText="" />);
+
+  await userEvent.click(screen.getByText(/add a question \+/i));
+  await userEvent.click(screen.getByText(/cancel/i));
 
   expect(screen.queryByText(/ask your question/i)).not.toBeInTheDocument();
 });

--- a/client/src/components/Questions/QandAModal.jsx
+++ b/client/src/components/Questions/QandAModal.jsx
@@ -5,30 +5,23 @@ import fetcher from '../../fetchers';
 export default function QandAModal({
   type,
   show,
-  closeModal,
+  setShowModal,
   product_id,
   question_id,
 }) {
   const blankForm = {
-    question: {
-      name: '',
-      body: '',
-      email: '',
-    },
-    answer: {
-      name: '',
-      body: '',
-      email: '',
-      photos: [],
-    },
+    name: '',
+    body: '',
+    email: '',
+    photos: [],
   };
-  const [addForm, setAddForm] = useState(blankForm[type]);
+  const [addForm, setAddForm] = useState(blankForm);
 
   const close = (e) => {
     if ((e.type === 'click' && e.target.classList.contains('modal-close'))
       || e.key === 'Enter') {
       setAddForm(blankForm);
-      closeModal(false);
+      setShowModal(false);
     }
   };
 
@@ -85,14 +78,14 @@ export default function QandAModal({
         </div>
         <div className="qa modal-body">
           <form id={`add-${type}-form`} onSubmit={submitForm}>
-            <div className={`qa add-${type}`}>
-              <label htmlFor={`add-${type}-form`}>
-                <div className="qa add-label">
-                  {type === 'question' ? 'Question' : 'Answer'}
-                </div>
+            <div className="qa add-body">
+              <label className="qa add-label" htmlFor={`${type}-bodybox`}>
+                {type === 'question' ? 'Question' : 'Answer'}
                 <textarea
                   type="text"
+                  id={`${type}-bodybox`}
                   name="body"
+                  form={`add-${type}-form`}
                   value={addForm.body}
                   onChange={handleChange}
                   maxLength="1000"
@@ -100,12 +93,14 @@ export default function QandAModal({
               </label>
             </div>
             <div className="qa add-personal">
-              <div className="qa add-name">
-                <label htmlFor={`add-${type}-form`}>
-                  <div className="qa add-label">Nickname</div>
+              <div className="qa add-nickname">
+                <label className="qa add-label" htmlFor="nicknamebox">
+                  Nickname
                   <input
                     type="text"
+                    id="nicknamebox"
                     name="name"
+                    form={`add-${type}-form`}
                     value={addForm.name}
                     onChange={handleChange}
                     maxLength="60"
@@ -116,11 +111,13 @@ export default function QandAModal({
                 </label>
               </div>
               <div className="qa add-email">
-                <label htmlFor={`add-${type}-form`}>
-                  <div className="qa add-label">Email</div>
+                <label className="qa add-label" htmlFor={`${type}-emailbox`}>
+                  Email
                   <input
                     type="text"
+                    id={`${type}-emailbox`}
                     name="email"
+                    form={`add-${type}-form`}
                     value={addForm.email}
                     onChange={handleChange}
                     maxLength="60"

--- a/client/src/components/Questions/Question.jsx
+++ b/client/src/components/Questions/Question.jsx
@@ -102,7 +102,7 @@ export default function Question({
           <QandAModal
             type="answer"
             show={showAddA}
-            closeModal={setShowAddA}
+            setShowModal={setShowAddA}
             question_id={question_id}
           />
         </span>

--- a/client/src/components/Questions/QuestionsList.jsx
+++ b/client/src/components/Questions/QuestionsList.jsx
@@ -69,7 +69,7 @@ export default function QuestionsList({
         <QandAModal
           type="question"
           show={showAddQ}
-          closeModal={setShowAddQ}
+          setShowModal={setShowAddQ}
           product_id={product_id}
         />
       </div>

--- a/client/src/components/Questions/styles/questions.css
+++ b/client/src/components/Questions/styles/questions.css
@@ -130,9 +130,10 @@
 .qa.search-icon {
   position: absolute;
   right: 1rem;
+  cursor: pointer;
 }
 
-/* ADD QUESTION FORM MODAL */
+/* ADD MODAL */
 
 .qa.modal-bg {
   position: fixed;
@@ -170,4 +171,8 @@
 .qa.add-personal {
   display: flex;
   justify-content: space-between;
+}
+
+.qa label {
+  display: grid;
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
     "test-watch": "jest --watch"
   },
   "jest": {
-    "verbose": true,
+    "coveragePathIgnorePatterns": [
+      "node_modules",
+      "__mocks__",
+      "__tests__/example_data",
+      "client/src/fetchers.js"
+    ],
+    "coverageDirectory": "<rootDir>/__tests__/coverage",
+    "verbose": false,
     "transform": {
       "^.+\\.[t|j]sx?$": "babel-jest"
     },


### PR DESCRIPTION
[Ticket](https://trello.com/c/FkdUk9uR/94-make-tests-for-all-qa-components)
- minor changes to [`QandAModal.jsx`](https://github.com/FEC2-Monsters-Inc/fec/compare/qanda-cleanup?expand=1#diff-8abbea07242e6f1a94d0c334820c6a2e9d3dd2d2a798ff2e23dd76094a8cdcde)
- finish testing all Q&A components
- coverage folder moved into `__tests__/coverage/`