### PR TITLE
#135 - added wishlist and cart tracking functionality with visual feedback

### DIFF
--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -8,6 +8,7 @@ import ProdInfo from './sub-comps/ProdInfo.jsx';
 import StyleSelect from './sub-comps/StyleSelect.jsx';
 import Cart from './sub-comps/Cart.jsx';
 import Description from './sub-comps/Description.jsx';
+import SessionInfo from './sub-comps/SessionInfo.jsx';
 
 export default function Overview({
   product, styles, reviews, recordClick,
@@ -20,6 +21,8 @@ export default function Overview({
   const [leftBtn, setLeftBtn] = useState(false);
   const [showSku, setShowSku] = useState('');
   const [quantity, setQuantity] = useState(1);
+  const [cart, setCart] = useState({});
+  const [wishlist, setWishlist] = useState({});
 
   // HELPER FUNCTIONS //
   const btnRenderCheck = () => {
@@ -68,7 +71,13 @@ export default function Overview({
     <div onClick={(e) => recordClick(e, 'Overview')}>
       <div id="header">
         <h1 className="temp-logo">FEC Project</h1>
-        <Search />
+        <div id="header-right">
+          <SessionInfo
+            cart={cart}
+            wishlist={wishlist}
+          />
+          <Search />
+        </div>
       </div>
       <div id="overview">
         <div className="left-main">
@@ -106,6 +115,10 @@ export default function Overview({
             currStyle={currStyle}
             quantity={quantity}
             setQuantity={setQuantity}
+            cart={cart}
+            addToCart={setCart}
+            wishlist={wishlist}
+            setWishlist={setWishlist}
           />
         </div>
         <div className="bottom-main">

--- a/client/src/components/Overview/overview.css
+++ b/client/src/components/Overview/overview.css
@@ -649,3 +649,56 @@ li {
     width: 50px;
   }
 }
+
+/* CART */
+
+#header-right {
+  display: flex;
+  align-items: center;
+}
+
+.session-btn-container {
+  display: block;
+  position: relative;
+  margin-right: 1rem;
+  cursor: pointer;
+}
+
+.session-icon {
+  color: #E60023;
+  width: 2rem;
+  height: 2rem;
+}
+
+#wishlist-icon{
+  stroke-width: 1.5px;
+  transform: translateY(-1);
+}
+
+.btn-qty {
+  position: absolute;
+  color: white;
+  background-color: #E60023;
+  font-size: 0.65rem;
+  height: 1rem;
+  width: 1rem;
+  border-radius: 1rem;
+  text-align: center;
+  line-height: 1rem;
+  right: 0;
+  top: 1.25rem;
+}
+
+#session-info {
+  display: flex;
+  align-items: center;
+}
+
+.star-cart-btn {
+  transition: color 300ms, background-color 300ms;
+}
+
+.star-cart-btn:hover, .star-cart-btn.active {
+  background-color: #E60023;
+  color: white;
+}

--- a/client/src/components/Overview/sub-comps/SessionInfo.jsx
+++ b/client/src/components/Overview/sub-comps/SessionInfo.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { HiOutlineShoppingBag } from 'react-icons/hi2';
+import { TbHeart } from 'react-icons/tb';
+
+export default function SessionInfo({
+  cart,
+  wishlist,
+}) {
+  const [numCart, setNumCart] = useState(0);
+  const [numWish, setNumWish] = useState(0);
+
+  useEffect(() => {
+    setNumCart(
+      Object.values(cart).reduce((acc, sku) => acc + sku.quantity, 0),
+    );
+  }, [cart]);
+
+  useEffect(() => {
+    setNumWish(Object.values(wishlist).length);
+  }, [wishlist]);
+
+  return (
+    <div id="session-info">
+      <div className="session-btn-container">
+        <TbHeart
+          id="wishlist-icon"
+          className="session-icon"
+        />
+        {numWish ? (
+          <div className="btn-qty">
+            {numWish}
+          </div>
+        ) : null}
+      </div>
+      <div className="session-btn-container">
+        <HiOutlineShoppingBag
+          className="session-icon"
+        />
+        {numCart ? (
+          <div className="btn-qty">
+            {numCart}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/M1UFctMi/135-feature-user-should-have-visual-confirmation-of-items-added-to-cart)
- user can now add skus to cart state
  - functionality is limited atm to only incrementing a visual counter
- user can now add styles to a wishlist
- possible future enhancements:
  - cart and wishlist save to localStorage
  - cart page with sum of prices and smth that looks like checkout
  - wishlist page showing all desired styles.. may want to include size