### PR TITLE
#140 - Fit images

### DIFF
--- a/client/src/components/Overview/overview.css
+++ b/client/src/components/Overview/overview.css
@@ -286,6 +286,8 @@ li {
   height: 100%;
   width: 100%;
   z-index: 0;
+  object-fit: cover;
+  object-position: center;
 }
 
 

--- a/client/src/components/Questions/styles/questions.css
+++ b/client/src/components/Questions/styles/questions.css
@@ -201,17 +201,24 @@
   margin: 1rem 0;
 }
 
+.qa.photos {
+  display: flex;
+  align-items: flex-end;
+}
+
 .qa.photo-sml {
-  max-width: 7.08rem;
-  max-height: 4rem;
   border-radius: 0.25rem;
-  margin: 0.25rem;
-  padding: 0.25rem;
-  cursor: pointer;
+  height: 5rem;
+  width: 7.11rem;
+  margin: 0 0.25rem;
+  object-fit: cover;
+  object-position: center;
 }
 
 .qa.photo-sml:hover {
-  box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.5);
+  box-shadow: rgb(0 0 0 / 16%) 0px 3px 6px, rgb(0 0 0 / 23%) 0px 3px 6px;
+  cursor: pointer;
+  transition: box-shadow 200ms;
 }
 
 .qa.answer-info {

--- a/client/src/components/Questions/styles/questions.css
+++ b/client/src/components/Questions/styles/questions.css
@@ -352,8 +352,8 @@
 }
 
 .image-modal {
-  max-height: 90%;
-  max-width: 90%;
+  max-height: 95%;
+  max-width: 95%;
   border-radius: 0.25rem;
   box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 4px 0px, rgba(14, 30, 37, 0.32) 0px 2px 16px 0px;
 }

--- a/client/src/components/Ratings/overhaul.css
+++ b/client/src/components/Ratings/overhaul.css
@@ -298,12 +298,23 @@
   padding: 1em 0 2em;
 }
 
+.review-tile-photos-container {
+  display: flex;
+}
+
 .review-tile-individual-photo {
-  max-width: 10%;
+  border-radius: 0.25rem;
+  height: 5rem;
+  width: 7.11rem;
+  margin: 0 0.25rem;
+  object-fit: cover;
+  object-position: center;
 }
 
 .review-tile-individual-photo:hover {
-  cursor: zoom-in;
+  box-shadow: rgb(0 0 0 / 16%) 0px 3px 6px, rgb(0 0 0 / 23%) 0px 3px 6px;
+  cursor: pointer;
+  transition: box-shadow 200ms;
 }
 
 .review-tile-container-1 {

--- a/client/src/components/Ratings/overhaul.css
+++ b/client/src/components/Ratings/overhaul.css
@@ -434,7 +434,7 @@
 /*  REVIEW TILE IMAGE MODAL */
 .review-image-modal-full-container {
   align-items: center;
-  animation: fadeIn .5s;
+  animation: fadeIn .25s;
   background-color: #0C1B3380;
   display: flex;
   justify-content: center;
@@ -451,8 +451,10 @@
 }
 
 .review-image-modal {
-  max-height: 75%;
-  max-width: 75%;
+  max-height: 95%;
+  max-width: 95%;
+  border-radius: 0.25rem;
+  box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 4px 0px, rgba(14, 30, 37, 0.32) 0px 2px 16px 0px;
 }
 
 /*  WRITE REVIEW MODAL  */


### PR DESCRIPTION
[Ticket](https://trello.com/c/AHQm7GvT/140-adjust-image-thumbnails-to-be-uniform)
- all thumbnails for reviews and questions will fit a 7:5 ratio
- added box-shadow and transition on hover
- increased size of images when expanded in modal
- modal images have shadow and border-radius

![image](https://user-images.githubusercontent.com/116389520/218175961-6245e918-f938-4594-abea-21dc887df2c7.png)
![image](https://user-images.githubusercontent.com/116389520/218175988-ef9e2204-0be5-4f55-894f-ca007ce8d914.png)
